### PR TITLE
Fix Document Orientation

### DIFF
--- a/identidoc/services/preprocessing.py
+++ b/identidoc/services/preprocessing.py
@@ -62,7 +62,7 @@ def image_pre_processing(image):
 
 # This function extracts text from the pre-processed image
 def tesseract_text_extraction(image):
-    tesseract_config = r'--oem 3 --psm 6'
+    tesseract_config = r'-c tessedit_char_whitelist=" -\'/@:()0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" --oem 3 --psm 6'
     #feeding the image to the tessercat
     extracted_text= pytesseract.image_to_string(image, output_type=pytesseract.Output.DICT, config=tesseract_config, lang='eng')
     return extracted_text

--- a/identidoc/services/preprocessing.py
+++ b/identidoc/services/preprocessing.py
@@ -22,7 +22,7 @@ def preprocess_file(filename):
         return filename
 
     image = file_conversion(filename)
-    rotate_image = rotate_image(image)
+    rotated_image = rotate_image(image)
     processed_image = image_pre_processing(rotated_image)
     extracted_text = tesseract_text_extraction(processed_image)
 
@@ -35,7 +35,7 @@ def preprocess_file(filename):
 # Output is a cv2 image that is oriented correctly by tesseract
 def rotate_image(image):
     orig_image_osd = pytesseract.image_to_osd(image)
-    image_rotation_angle = re.search('(?<=Rotate: )\d+', osd_rotated_image).group(0)
+    image_rotation_angle = re.search('(?<=Rotate: )\d+', orig_image_osd).group(0)
 
     correctly_oriented_image = None
 

--- a/identidoc/services/preprocessing.py
+++ b/identidoc/services/preprocessing.py
@@ -34,10 +34,13 @@ def preprocess_file(filename):
 # Input is a cv2 image that may or may not be oriented correctly
 # Output is a cv2 image that is oriented correctly by tesseract
 def rotate_image(image):
-    orig_image_osd = pytesseract.image_to_osd(image)
-    image_rotation_angle = re.search('(?<=Rotate: )\d+', orig_image_osd).group(0)
+    try:
+        orig_image_osd = pytesseract.image_to_osd(image)
+        image_rotation_angle = re.search('(?<=Rotate: )\d+', orig_image_osd).group(0)
+    except:
+        return image
 
-    correctly_oriented_image = None
+    correctly_oriented_image = image
 
     if image_rotation_angle == '0':
         correctly_oriented_image = image
@@ -62,7 +65,7 @@ def image_pre_processing(image):
 
 # This function extracts text from the pre-processed image
 def tesseract_text_extraction(image):
-    tesseract_config = r'-c tessedit_char_whitelist=" .-\'/@:()0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" --oem 3 --psm 6'
+    tesseract_config = r'-c tessedit_char_whitelist=" -.@/()%:\',?!0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" --oem 3 --psm 6'
     #feeding the image to the tessercat
     extracted_text= pytesseract.image_to_string(image, output_type=pytesseract.Output.DICT, config=tesseract_config, lang='eng')
     return extracted_text

--- a/identidoc/services/preprocessing.py
+++ b/identidoc/services/preprocessing.py
@@ -62,7 +62,7 @@ def image_pre_processing(image):
 
 # This function extracts text from the pre-processed image
 def tesseract_text_extraction(image):
-    tesseract_config = r'-c tessedit_char_whitelist=" -\'/@:()0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" --oem 3 --psm 6'
+    tesseract_config = r'-c tessedit_char_whitelist=" .-\'/@:()0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" --oem 3 --psm 6'
     #feeding the image to the tessercat
     extracted_text= pytesseract.image_to_string(image, output_type=pytesseract.Output.DICT, config=tesseract_config, lang='eng')
     return extracted_text

--- a/identidoc/services/preprocessing.py
+++ b/identidoc/services/preprocessing.py
@@ -1,6 +1,7 @@
 import cv2
 import pytesseract
 import json
+import re
 import subprocess
 import sys
 import os
@@ -21,13 +22,33 @@ def preprocess_file(filename):
         return filename
 
     image = file_conversion(filename)
-    processed_image = image_pre_processing(image)
+    rotate_image = rotate_image(image)
+    processed_image = image_pre_processing(rotated_image)
     extracted_text = tesseract_text_extraction(processed_image)
 
     # This returns the abosule filepath to the extracted text.
     return save_text_to_file(extracted_text)
 
 
+# This function rotates the image correctly
+# Input is a cv2 image that may or may not be oriented correctly
+# Output is a cv2 image that is oriented correctly by tesseract
+def rotate_image(image):
+    orig_image_osd = pytesseract.image_to_osd(image)
+    image_rotation_angle = re.search('(?<=Rotate: )\d+', osd_rotated_image).group(0)
+
+    correctly_oriented_image = None
+
+    if image_rotation_angle == '0':
+        correctly_oriented_image = image
+    elif image_rotation_angle == '90':
+        correctly_oriented_image = cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
+    elif image_rotation_angle == '180':
+        correctly_oriented_image = cv2.rotate(image, cv2.ROTATE_180)
+    elif image_rotation_angle == '270':
+        correctly_oriented_image = cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
+
+    return correctly_oriented_image
 
 
 # This function performs pre-processiong on the image file provided

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -7,6 +7,10 @@
 # Run identiDoc with the command
 # python identidoc/__init__.py
 
+# Add these in, CircleCI didn't like it when these were missing
+sudo apt update
+sudo apt upgrade
+
 # Install venv
 sudo apt install python3-venv
 sudo apt install tesseract-ocr

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -11,6 +11,6 @@ class TestEnv(unittest.TestCase):
         temp_path = os.environ.get('IDENTIDOC_TEMP_PATH', 'ERROR')
         db_path = os.environ.get('IDENTIDOC_DB', 'ERROR')
 
-        assert upload_path is not 'ERROR'
-        assert temp_path is not 'ERROR'
-        assert db_path is not 'ERROR'
+        assert upload_path != 'ERROR'
+        assert temp_path != 'ERROR'
+        assert db_path != 'ERROR'


### PR DESCRIPTION
Document is now rotated to be right side up before the characters are read. A character whitelist has also been added to prevent obscure characters from being detected. This may have to be adjusted later.